### PR TITLE
Remove dismissed dependencies

### DIFF
--- a/nethserver-rh-php71-php-fpm.spec
+++ b/nethserver-rh-php71-php-fpm.spec
@@ -9,9 +9,9 @@ BuildArch: noarch
 BuildRequires: nethserver-devtools
 
 Requires: rh-php71, rh-php71-php-fpm
-Requires: rh-php71-php-bcmath, rh-php71-php-gd, sclo-php71-php-imap
+Requires: rh-php71-php-bcmath, rh-php71-php-gd
 Requires: rh-php71-php-ldap, rh-php71-php-enchant, rh-php71-php-mbstring
-Requires: rh-php71-php-pdo, sclo-php71-php-tidy, rh-php71-php-mysqlnd
+Requires: rh-php71-php-pdo, rh-php71-php-mysqlnd
 Requires: rh-php71-php-soap, rh-php71-php-pgsql
 Requires: rh-php71-php-pecl-apcu, rh-php71-php-intl
 Requires: rh-php71-php-opcache


### PR DESCRIPTION
Removed packages are no more available inside upstream repos.

Currently, this issue is preventing publication of updates into NS repo with the following error:
```
package: nethserver-rh-php71-php-fpm-1.0.1-1.ns7.noarch from updates
  unresolved deps: 
     sclo-php71-php-tidy
     sclo-php71-php-imap
package: nethserver-rh-php71-php-fpm-1.1.0-1.ns7.noarch from updates
  unresolved deps: 
     sclo-php71-php-tidy
     sclo-php71-php-imap
package: nethserver-rh-php71-php-fpm-1.1.1-1.ns7.noarch from updates
  unresolved deps: 
     sclo-php71-php-tidy
     sclo-php71-php-imap
```